### PR TITLE
refactor: add TypeScript support to Redux store and SongPlaylist component

### DIFF
--- a/redux-playlist-app/src/components/SongPlaylist.tsx
+++ b/redux-playlist-app/src/components/SongPlaylist.tsx
@@ -5,6 +5,7 @@ import {
   type AppDispatch,
   removeSong,
   type RootState,
+  type Song,
 } from "../store";
 
 function SongPlaylist() {
@@ -12,16 +13,16 @@ function SongPlaylist() {
   // Get list of songs
 
   // Strongly typed selector
-  const songPlaylist: string[] = useSelector((state: RootState) => state.songs);
+  const songPlaylist: Song[] = useSelector((state: RootState) => state.songs);
 
   // Strongly typed dispatch
   const dispatch = useDispatch<AppDispatch>();
 
-  const handleSongAdd = (song: string) => {
+  const handleSongAdd = (song: Song) => {
     const action = addSong(song);
     dispatch(action);
   };
-  const handleSongRemove = (song: string) => {
+  const handleSongRemove = (song: Song) => {
     dispatch(removeSong(song));
   };
 

--- a/redux-playlist-app/src/store/index.ts
+++ b/redux-playlist-app/src/store/index.ts
@@ -5,7 +5,7 @@ import {
 } from "@reduxjs/toolkit";
 
 // Define the type for a song (can be expanded later)
-type Song = string;
+export type Song = string;
 
 const initialSongsState: Song[] = [];
 


### PR DESCRIPTION
- Defined Song type and initial state with strict typing
- Annotated action payloads using PayloadAction<string>
- Exported RootState using ReturnType<typeof store.getState>
- Typed useSelector with RootState to resolve 'unknown' issue
- Ensured SongPlaylist uses type-safe Redux hooks and props