### PR TITLE
feat: add reset functionality to clear both songs and movies playlists

### DIFF
--- a/redux-playlist-app/src/App.tsx
+++ b/redux-playlist-app/src/App.tsx
@@ -1,9 +1,16 @@
+import { useDispatch } from "react-redux";
 import MoviePlaylist from "./components/MoviePlaylist";
 import SongPlaylist from "./components/SongPlaylist";
 
+import { resetMovies, resetSongs, type AppDispatch } from "./store";
+
 export default function App() {
+  // Strongly typed dispatch
+  const dispatch = useDispatch<AppDispatch>();
+
   const handleResetClick = () => {
-    //
+    dispatch(resetMovies());
+    dispatch(resetSongs());
   };
 
   return (

--- a/redux-playlist-app/src/components/MoviePlaylist.tsx
+++ b/redux-playlist-app/src/components/MoviePlaylist.tsx
@@ -1,17 +1,30 @@
+import { useDispatch, useSelector } from "react-redux";
 import { createRandomMovie } from "../data";
+import {
+  addMovie,
+  removeMovie,
+  type AppDispatch,
+  type Movie,
+  type RootState,
+} from "../store";
 
 function MoviePlaylist() {
-  // To Do:
   // Get list of movies
-  const moviePlaylist: string[] = [];
+  // Strongly typed selector
+  const moviePlaylist: Movie[] = useSelector(
+    (state: RootState) => state.movies
+  );
 
-  const handleMovieAdd = (movie: string) => {
-    // To Do:
+  // Strongly typed dispatch
+  const dispatch = useDispatch<AppDispatch>();
+
+  const handleMovieAdd = (movie: Movie) => {
     // Add movie to list of movies
+    dispatch(addMovie(movie));
   };
-  const handleMovieRemove = (movie: string) => {
-    // To Do:
+  const handleMovieRemove = (movie: Movie) => {
     // Remove movie from list of movies
+    dispatch(removeMovie(movie));
   };
 
   const renderedMovies = moviePlaylist.map((movie) => {

--- a/redux-playlist-app/src/store/index.ts
+++ b/redux-playlist-app/src/store/index.ts
@@ -6,8 +6,10 @@ import {
 
 // Define the type for a song (can be expanded later)
 export type Song = string;
+export type Movie = string;
 
 const initialSongsState: Song[] = [];
+const initialMoviesState: Movie[] = [];
 
 const songsSlice = createSlice({
   name: "song",
@@ -20,12 +22,32 @@ const songsSlice = createSlice({
     removeSong: (state, action: PayloadAction<string>) => {
       return state.filter((song) => song !== action.payload);
     },
+    reset: () => {
+      return [];
+    },
+  },
+});
+
+const moviesSlice = createSlice({
+  name: "movie",
+  initialState: initialMoviesState,
+  reducers: {
+    addMovie(state, action: PayloadAction<string>) {
+      state.push(action.payload);
+    },
+    removeMovie: (state, action: PayloadAction<string>) => {
+      return state.filter((movie) => movie !== action.payload);
+    },
+    reset: () => {
+      return [];
+    },
   },
 });
 
 export const store = configureStore({
   reducer: {
     songs: songsSlice.reducer,
+    movies: moviesSlice.reducer,
   },
 });
 
@@ -34,4 +56,9 @@ export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
 
 //step 2
-export const { addSong, removeSong } = songsSlice.actions;
+export const { addSong, removeSong, reset: resetSongs } = songsSlice.actions;
+export const {
+  addMovie,
+  removeMovie,
+  reset: resetMovies,
+} = moviesSlice.actions;


### PR DESCRIPTION
- Added `reset` reducer to both songsSlice and moviesSlice
- Exported as `resetSongs` and `resetMovies` respectively
- Implemented Reset Both Playlists button in App.tsx
- Dispatches both reset actions on click