### PR TITLE
feat(songsSlice): handle movie/reset action via extraReducers

### DIFF
--- a/redux-playlist-app/src/App.tsx
+++ b/redux-playlist-app/src/App.tsx
@@ -2,7 +2,7 @@ import { useDispatch } from "react-redux";
 import MoviePlaylist from "./components/MoviePlaylist";
 import SongPlaylist from "./components/SongPlaylist";
 
-import { resetMovies, resetSongs, type AppDispatch } from "./store";
+import { resetMovies, type AppDispatch } from "./store";
 
 export default function App() {
   // Strongly typed dispatch
@@ -10,7 +10,6 @@ export default function App() {
 
   const handleResetClick = () => {
     dispatch(resetMovies());
-    dispatch(resetSongs());
   };
 
   return (

--- a/redux-playlist-app/src/store/index.ts
+++ b/redux-playlist-app/src/store/index.ts
@@ -22,9 +22,11 @@ const songsSlice = createSlice({
     removeSong: (state, action: PayloadAction<string>) => {
       return state.filter((song) => song !== action.payload);
     },
-    reset: () => {
+  },
+  extraReducers: (builder) => {
+    builder.addCase("movie/reset", () => {
       return [];
-    },
+    });
   },
 });
 
@@ -56,7 +58,7 @@ export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
 
 //step 2
-export const { addSong, removeSong, reset: resetSongs } = songsSlice.actions;
+export const { addSong, removeSong } = songsSlice.actions;
 export const {
   addMovie,
   removeMovie,


### PR DESCRIPTION
- Added extraReducers to songsSlice to listen for the 'movie/reset' action type.
- This ensures that when the resetBothPlaylists button is clicked, the songs state is also reset to an empty array, aligning with the behavior in moviesSlice.