### PR TITLE
refactor(songsSlice): use action creator in extraReducers instead of hardcoded type

### DIFF
--- a/redux-playlist-app/src/store/index.ts
+++ b/redux-playlist-app/src/store/index.ts
@@ -24,7 +24,7 @@ const songsSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase("movie/reset", () => {
+    builder.addCase(moviesSlice.actions.reset, () => {
       return [];
     });
   },


### PR DESCRIPTION
- Replaced hardcoded 'movie/reset' string in extraReducers with moviesSlice.actions.reset.
- This ensures stronger type safety and better maintainability by referencing the actual action creator.