### PR TITLE
refactor: decouple slice dependencies by introducing shared reset action

### DIFF
--- a/redux-playlist-app/src/App.tsx
+++ b/redux-playlist-app/src/App.tsx
@@ -2,14 +2,14 @@ import { useDispatch } from "react-redux";
 import MoviePlaylist from "./components/MoviePlaylist";
 import SongPlaylist from "./components/SongPlaylist";
 
-import { resetMovies, type AppDispatch } from "./store";
+import { reset, type AppDispatch } from "./store";
 
 export default function App() {
   // Strongly typed dispatch
   const dispatch = useDispatch<AppDispatch>();
 
   const handleResetClick = () => {
-    dispatch(resetMovies());
+    dispatch(reset());
   };
 
   return (

--- a/redux-playlist-app/src/store/index.ts
+++ b/redux-playlist-app/src/store/index.ts
@@ -1,5 +1,6 @@
 import {
   configureStore,
+  createAction,
   createSlice,
   type PayloadAction,
 } from "@reduxjs/toolkit";
@@ -11,6 +12,9 @@ export type Movie = string;
 const initialSongsState: Song[] = [];
 const initialMoviesState: Movie[] = [];
 
+export const reset = createAction("app/reset");
+
+console.log(reset());
 const songsSlice = createSlice({
   name: "song",
   initialState: initialSongsState,
@@ -24,7 +28,7 @@ const songsSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(moviesSlice.actions.reset, () => {
+    builder.addCase(reset, () => {
       return [];
     });
   },
@@ -40,9 +44,11 @@ const moviesSlice = createSlice({
     removeMovie: (state, action: PayloadAction<string>) => {
       return state.filter((movie) => movie !== action.payload);
     },
-    reset: () => {
+  },
+  extraReducers: (builder) => {
+    builder.addCase(reset, () => {
       return [];
-    },
+    });
   },
 });
 
@@ -59,8 +65,4 @@ export type AppDispatch = typeof store.dispatch;
 
 //step 2
 export const { addSong, removeSong } = songsSlice.actions;
-export const {
-  addMovie,
-  removeMovie,
-  reset: resetMovies,
-} = moviesSlice.actions;
+export const { addMovie, removeMovie } = moviesSlice.actions;


### PR DESCRIPTION
- Created a standalone 'app/reset' action using createAction
- Updated moviesSlice and songsSlice to handle the shared reset action via extraReducers
- Removed hardcoded dependency on 'moviesSlice.actions.reset' inside songsSlice
- Improves modularity, reduces coupling between slices, and makes reset logic reusable