### PR TITLE
refactor: centralize reset action and decouple state slices

### DIFF
--- a/redux-playlist-app/.vite/deps/_metadata.json
+++ b/redux-playlist-app/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "9e7fd3bc",
+  "configHash": "41628f44",
+  "lockfileHash": "61a00f32",
+  "browserHash": "7564f291",
+  "optimized": {},
+  "chunks": {}
+}

--- a/redux-playlist-app/.vite/deps/package.json
+++ b/redux-playlist-app/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/redux-playlist-app/src/store/actions.ts
+++ b/redux-playlist-app/src/store/actions.ts
@@ -1,0 +1,3 @@
+import { createAction } from "@reduxjs/toolkit";
+
+export const reset = createAction("app/reset");

--- a/redux-playlist-app/src/store/index.ts
+++ b/redux-playlist-app/src/store/index.ts
@@ -1,61 +1,14 @@
-import {
-  configureStore,
-  createAction,
-  createSlice,
-  type PayloadAction,
-} from "@reduxjs/toolkit";
-
-// Define the type for a song (can be expanded later)
-export type Song = string;
-export type Movie = string;
-
-const initialSongsState: Song[] = [];
-const initialMoviesState: Movie[] = [];
-
-export const reset = createAction("app/reset");
-
-console.log(reset());
-const songsSlice = createSlice({
-  name: "song",
-  initialState: initialSongsState,
-  reducers: {
-    addSong(state, action: PayloadAction<string>) {
-      //
-      state.push(action.payload);
-    },
-    removeSong: (state, action: PayloadAction<string>) => {
-      return state.filter((song) => song !== action.payload);
-    },
-  },
-  extraReducers: (builder) => {
-    builder.addCase(reset, () => {
-      return [];
-    });
-  },
-});
-
-const moviesSlice = createSlice({
-  name: "movie",
-  initialState: initialMoviesState,
-  reducers: {
-    addMovie(state, action: PayloadAction<string>) {
-      state.push(action.payload);
-    },
-    removeMovie: (state, action: PayloadAction<string>) => {
-      return state.filter((movie) => movie !== action.payload);
-    },
-  },
-  extraReducers: (builder) => {
-    builder.addCase(reset, () => {
-      return [];
-    });
-  },
-});
+import { configureStore } from "@reduxjs/toolkit";
+import songsSlice from "./slices/songsSlice";
+import { addSong, removeSong } from "./slices/songsSlice";
+import moviesSlice from "./slices/moviesSlice";
+import { addMovie, removeMovie } from "./slices/moviesSlice";
+import { reset } from "./actions";
 
 export const store = configureStore({
   reducer: {
-    songs: songsSlice.reducer,
-    movies: moviesSlice.reducer,
+    songs: songsSlice,
+    movies: moviesSlice,
   },
 });
 
@@ -63,6 +16,4 @@ export const store = configureStore({
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
 
-//step 2
-export const { addSong, removeSong } = songsSlice.actions;
-export const { addMovie, removeMovie } = moviesSlice.actions;
+export { addSong, removeSong, addMovie, removeMovie, reset };

--- a/redux-playlist-app/src/store/slices/moviesSlice.ts
+++ b/redux-playlist-app/src/store/slices/moviesSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { reset } from "../actions";
+
+export type Movie = string;
+
+const initialMoviesState: Movie[] = [];
+
+const moviesSlice = createSlice({
+  name: "movie",
+  initialState: initialMoviesState,
+  reducers: {
+    addMovie(state, action: PayloadAction<Movie>) {
+      state.push(action.payload);
+    },
+    removeMovie: (state, action: PayloadAction<Movie>) => {
+      return state.filter((movie) => movie !== action.payload);
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(reset, () => {
+      return [];
+    });
+  },
+});
+
+export const { addMovie, removeMovie } = moviesSlice.actions;
+export default moviesSlice.reducer;

--- a/redux-playlist-app/src/store/slices/songsSlice.ts
+++ b/redux-playlist-app/src/store/slices/songsSlice.ts
@@ -1,0 +1,29 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { reset } from "../actions";
+
+// Define the type for a song (can be expanded later)
+export type Song = string;
+
+const initialSongsState: Song[] = [];
+
+const songsSlice = createSlice({
+  name: "song",
+  initialState: initialSongsState,
+  reducers: {
+    addSong(state, action: PayloadAction<Song>) {
+      //
+      state.push(action.payload);
+    },
+    removeSong: (state, action: PayloadAction<Song>) => {
+      return state.filter((song) => song !== action.payload);
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(reset, () => {
+      return [];
+    });
+  },
+});
+
+export const { addSong, removeSong } = songsSlice.actions;
+export default songsSlice.reducer;


### PR DESCRIPTION
- Moved reset action to a shared store/actions.ts file using createAction
- Updated moviesSlice and songsSlice to handle global reset via extraReducers
- Removed slice-specific reset definitions to reduce coupling
- Exported reset and CRUD actions from store/index.ts for simplified imports
- Ensured clean, scalable architecture with strong typing and modular design