### PR TITLE
feat(car-form): implement controlled input for car name with typed event handler

### DIFF
--- a/cars-redux/src/components/CarForm.tsx
+++ b/cars-redux/src/components/CarForm.tsx
@@ -1,7 +1,33 @@
 import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { changeName, type RootState } from "../store";
 
 const CarForm = () => {
-  return <></>;
+  const dispatch = useDispatch();
+
+  const name = useSelector((state: RootState) => state.form.name);
+
+  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(changeName(event.target.value));
+  };
+
+  return (
+    <div className="car-form panel">
+      <h4 className="subtitle is-3">Add Car</h4>
+      <form>
+        <div className="field-group">
+          <div className="field">
+            <label className="label">Name</label>
+            <input
+              className="input is-expanded"
+              value={name}
+              onChange={handleNameChange}
+            />
+          </div>
+        </div>
+      </form>
+    </div>
+  );
 };
 
 export default CarForm;


### PR DESCRIPTION
Added a controlled input field for the car name in the CarForm component. Integrated it with Redux by dispatching `changeName` on input change. Used `React.ChangeEvent<HTMLInputElement>` to ensure type safety on the event object.