### PR TITLE
feat(car-form): implement controlled input for car cost with typed event handler

### DIFF
--- a/cars-redux/src/components/CarForm.tsx
+++ b/cars-redux/src/components/CarForm.tsx
@@ -1,16 +1,23 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { changeName, type RootState } from "../store";
+import { changeCost, changeName, type RootState } from "../store";
 
 const CarForm = () => {
   const dispatch = useDispatch();
 
   const name = useSelector((state: RootState) => state.form.name);
+  const cost = useSelector((state: RootState) => state.form.cost);
 
   const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(changeName(event.target.value));
   };
 
+  const handleCostChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    //Even when you set <input type="number" />,
+    // the value returned from event.target.value is still a string, not a number.
+    const cost = parseInt(event.target.value) || 0;
+    dispatch(changeCost(cost));
+  };
   return (
     <div className="car-form panel">
       <h4 className="subtitle is-3">Add Car</h4>
@@ -22,6 +29,15 @@ const CarForm = () => {
               className="input is-expanded"
               value={name}
               onChange={handleNameChange}
+            />
+          </div>
+          <div className="field">
+            <label className="label">Cost</label>
+            <input
+              className="input is-expanded"
+              value={cost || " "}
+              onChange={handleCostChange}
+              type="number"
             />
           </div>
         </div>


### PR DESCRIPTION
Added a controlled input field for the car cost in the CarForm component. Integrated it with Redux by dispatching `changeCost` on input change. Used `React.ChangeEvent<HTMLInputElement>` to ensure type safety on the event object.