### PR TITLE
feat(store): add AppDispatch and RootState types for typed Redux usage

### DIFF
--- a/media-app/src/components/UsersList.tsx
+++ b/media-app/src/components/UsersList.tsx
@@ -1,6 +1,13 @@
-import React from "react";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { fetchUsers, type AppDispatch } from "../store";
 
 const UsersList = () => {
+  const dispath = useDispatch<AppDispatch>();
+
+  useEffect(() => {
+    dispath(fetchUsers());
+  }, [dispath]);
   return <div>Users List</div>;
 };
 

--- a/media-app/src/store/index.ts
+++ b/media-app/src/store/index.ts
@@ -7,3 +7,8 @@ export const store = configureStore({
   },
 });
 
+export * from "./thunks/fetchUsers";
+
+// These are your inferred types based on the store structure
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
- Exported AppDispatch and RootState from store to enable type-safe dispatching and selectors
- Updated UsersList component to use typed useDispatch with AppDispatch
- Re-exported thunk (fetchUsers) from store index for cleaner imports