### PR TITLE
feat: implement async user creation with addUser thunk and integrate into UI

### DIFF
--- a/media-app/db.json
+++ b/media-app/db.json
@@ -1,5 +1,22 @@
 {
-  "users": [{ "id": 1, "name": "Myra" }],
+  "users": [
+    {
+      "id": "1",
+      "name": "Myra"
+    },
+    {
+      "id": "04e6",
+      "name": "Kelly Howe"
+    },
+    {
+      "id": "94c7",
+      "name": "Sonia Orn"
+    },
+    {
+      "id": "6f82",
+      "name": "Erick Ledner"
+    }
+  ],
   "albums": [],
   "photos": []
 }

--- a/media-app/package-lock.json
+++ b/media-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "media-app",
       "version": "0.0.0",
       "dependencies": {
+        "@faker-js/faker": "^9.9.0",
         "@reduxjs/toolkit": "^2.8.2",
         "axios": "^1.11.0",
         "classnames": "^2.5.1",
@@ -922,6 +923,22 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/media-app/package.json
+++ b/media-app/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@faker-js/faker": "^9.9.0",
     "@reduxjs/toolkit": "^2.8.2",
     "axios": "^1.11.0",
     "classnames": "^2.5.1",

--- a/media-app/src/components/UsersList.tsx
+++ b/media-app/src/components/UsersList.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
-import { fetchUsers } from "../store";
+import { fetchUsers, addUser } from "../store";
+import Button from "./Button";
 import { useAppDispatch, useAppSelector } from "../store/hooks";
 
 const UsersList = () => {
@@ -20,7 +21,29 @@ const UsersList = () => {
   if (error) {
     return <div>Error Fetching data ...</div>;
   }
-  return <div>{data.length}</div>;
+
+  const renderedUsers = data.map((user) => {
+    return (
+      <div key={user.id} className="mb-2 border rounded">
+        <div className="flex p-2 justify-between items-center cursor-pointer">
+          {user.name}
+        </div>
+      </div>
+    );
+  });
+
+  const handleUserAdd = () => {
+    dispath(addUser());
+  };
+  return (
+    <div>
+      <div className="flex flex-row justify-between m-3">
+        <h1 className="m-2 text-xl">Users</h1>
+        <Button onClick={handleUserAdd}>+ Add User</Button>
+      </div>
+      {renderedUsers}
+    </div>
+  );
 };
 
 export default UsersList;

--- a/media-app/src/store/index.ts
+++ b/media-app/src/store/index.ts
@@ -8,6 +8,7 @@ export const store = configureStore({
 });
 
 export * from "./thunks/fetchUsers";
+export * from "./thunks/addUser";
 
 // These are your inferred types based on the store structure
 export type RootState = ReturnType<typeof store.getState>;

--- a/media-app/src/store/slices/usersSlice.ts
+++ b/media-app/src/store/slices/usersSlice.ts
@@ -1,37 +1,51 @@
-  import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
-  import type { User } from "../../types/media";
-  import { fetchUsers } from "../thunks/fetchUsers";
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { User } from "../../types/media";
+import { fetchUsers } from "../thunks/fetchUsers";
+import { addUser } from "../thunks/addUser";
 
-  interface UsersState {
-    data: User[];
-    isLoading: boolean;
-    error: null | string;
-  }
+interface UsersState {
+  data: User[];
+  isLoading: boolean;
+  error: null | string;
+}
 
-  const initalUsersState: UsersState = {
-    data: [],
-    isLoading: false,
-    error: null,
-  };
+const initalUsersState: UsersState = {
+  data: [],
+  isLoading: false,
+  error: null,
+};
 
-  const usersSlice = createSlice({
-    name: "users",
-    initialState: initalUsersState,
-    reducers: {},
-    extraReducers: (builder) => {
-      builder
-        .addCase(fetchUsers.pending, (state) => {
-          state.isLoading = true;
-        })
-        .addCase(fetchUsers.fulfilled, (state, action: PayloadAction<User[]>) => {
-          state.isLoading = false;
-          state.data = action.payload;
-        })
-        .addCase(fetchUsers.rejected, (state, action) => {
-          state.isLoading = false;
-          state.error = action.error.message || "Something went wrong";
-        });
-    },
-  });
+const usersSlice = createSlice({
+  name: "users",
+  initialState: initalUsersState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchUsers.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(fetchUsers.fulfilled, (state, action: PayloadAction<User[]>) => {
+        state.isLoading = false;
+        state.data = action.payload;
+      })
+      .addCase(fetchUsers.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.error.message || "Something went wrong";
+      });
 
-  export const usersReducer = usersSlice.reducer;
+    builder
+      .addCase(addUser.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(addUser.fulfilled, (state, action: PayloadAction<User>) => {
+        state.isLoading = false;
+        state.data.push(action.payload);
+      })
+      .addCase(addUser.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.error.message || "Something went wrong";
+      });
+  },
+});
+
+export const usersReducer = usersSlice.reducer;

--- a/media-app/src/store/thunks/addUser.ts
+++ b/media-app/src/store/thunks/addUser.ts
@@ -1,0 +1,13 @@
+import { faker } from "@faker-js/faker";
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+import { type User } from "../../types/media";
+
+const addUser = createAsyncThunk<User, void>("users/add", async () => {
+  const response = await axios.post<User>("http://localhost:3005/users", {
+    name: faker.name.fullName(),
+  });
+  return response.data;
+});
+
+export { addUser };


### PR DESCRIPTION
- Created addUser async thunk using createAsyncThunk and faker for random user generation
- Handled addUser states (pending, fulfilled, rejected) in usersSlice reducer
- Exposed addUser from store index
- Updated UsersList.tsx to dispatch addUser on button click and render newly added users