### PR TITLE
fix: pass undefined to thunk in useEffect to match hook signature

### DIFF
--- a/media-app/.gitignore
+++ b/media-app/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+db.json

--- a/media-app/db.json
+++ b/media-app/db.json
@@ -7,6 +7,14 @@
     {
       "id": "29e6",
       "name": "Camille Kreiger"
+    },
+    {
+      "id": "1eae",
+      "name": "Hannah Kozey"
+    },
+    {
+      "id": "04ea",
+      "name": "Shannon Schaden"
     }
   ],
   "albums": [],

--- a/media-app/src/components/UsersList.tsx
+++ b/media-app/src/components/UsersList.tsx
@@ -13,7 +13,7 @@ const UsersList = () => {
   const [doLoadUsers, isUsersLoading, usersLoadingError] = useThunk(fetchUsers);
 
   useEffect(() => {
-    doLoadUsers();
+    doLoadUsers(undefined);
   }, [doLoadUsers]);
 
   if (isUsersLoading) {
@@ -35,7 +35,7 @@ const UsersList = () => {
   });
 
   const handleUserAdd = () => {
-    doAddUser();
+    doAddUser(undefined);
   };
 
   return (


### PR DESCRIPTION
The custom `useThunk` hook expects an argument, even if the thunk itself takes none. Updated the `doLoadUsers()` call inside `useEffect` to `doLoadUsers(undefined)` to avoid TypeScript error (Expected 1 arguments, but got 0).