### PR TITLE
feat: integrate RTK Query to fetch albums per user

### DIFF
--- a/media-app/db.json
+++ b/media-app/db.json
@@ -5,18 +5,18 @@
       "name": "Myra"
     },
     {
-      "id": "1eae",
+      "id": "2",
       "name": "Hannah Kozey"
     },
     {
-      "id": "04ea",
+      "id": "3",
       "name": "Shannon Schaden"
     },
     {
-      "id": "5b9e",
+      "id": "4",
       "name": "Brent Kassulke"
     }
   ],
-  "albums": [],
+  "albums": [{ "id": 10, "title": "Hiking Trip", "userId": 1 }],
   "photos": []
 }

--- a/media-app/src/components/AlbumsList.tsx
+++ b/media-app/src/components/AlbumsList.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import type { User } from "../types/media";
+import { useFetchAlbumsQuery } from "../store";
+
+interface AlbumsListProps {
+  user: User;
+}
+const AlbumsList: React.FC<AlbumsListProps> = ({ user }) => {
+  const { data, error, isLoading } = useFetchAlbumsQuery(user);
+  console.log(data, error, isLoading);
+  return <div>Albums for {user.name}</div>;
+};
+
+export default AlbumsList;

--- a/media-app/src/components/UserListItem.tsx
+++ b/media-app/src/components/UserListItem.tsx
@@ -5,6 +5,7 @@ import { deleteUser } from "../store";
 import Button from "./Button";
 import { GoTrash } from "react-icons/go";
 import ExpandablePanel from "./ExpandablePanel";
+import AlbumsList from "./AlbumsList";
 
 interface UserListItemProps {
   user: User;
@@ -27,7 +28,11 @@ const UserListItem: React.FC<UserListItemProps> = ({ user }) => {
     </>
   );
 
-  return <ExpandablePanel header={header}>Content !!!</ExpandablePanel>;
+  return (
+    <ExpandablePanel header={header}>
+      <AlbumsList user={user} />
+    </ExpandablePanel>
+  );
 };
 
 export default UserListItem;

--- a/media-app/src/output.css
+++ b/media-app/src/output.css
@@ -208,9 +208,6 @@
   .flex {
     display: flex;
   }
-  .table {
-    display: table;
-  }
   .h-6 {
     height: calc(var(--spacing) * 6);
   }
@@ -223,12 +220,6 @@
   .w-full {
     width: 100%;
   }
-  .border-collapse {
-    border-collapse: collapse;
-  }
-  .transform {
-    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
-  }
   .animate-pulse {
     animation: var(--animate-pulse);
   }
@@ -237,9 +228,6 @@
   }
   .cursor-pointer {
     cursor: pointer;
-  }
-  .resize {
-    resize: both;
   }
   .flex-row {
     flex-direction: row;
@@ -309,9 +297,6 @@
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
   }
-  .py-1 {
-    padding-block: calc(var(--spacing) * 1);
-  }
   .py-1\.5 {
     padding-block: calc(var(--spacing) * 1.5);
   }
@@ -337,9 +322,6 @@
   .text-yellow-400 {
     color: var(--color-yellow-400);
   }
-  .underline {
-    text-decoration-line: underline;
-  }
   .opacity-80 {
     opacity: 80%;
   }
@@ -351,26 +333,6 @@
     outline-style: var(--tw-outline-style);
     outline-width: 1px;
   }
-}
-@property --tw-rotate-x {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-rotate-y {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-rotate-z {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-skew-x {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-skew-y {
-  syntax: "*";
-  inherits: false;
 }
 @property --tw-border-style {
   syntax: "*";
@@ -460,11 +422,6 @@
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
-      --tw-rotate-x: initial;
-      --tw-rotate-y: initial;
-      --tw-rotate-z: initial;
-      --tw-skew-x: initial;
-      --tw-skew-y: initial;
       --tw-border-style: solid;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;

--- a/media-app/src/store/apis/albumsApi.ts
+++ b/media-app/src/store/apis/albumsApi.ts
@@ -1,0 +1,26 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+const albumsApi = createApi({
+  reducerPath: "albums",
+  baseQuery: fetchBaseQuery({
+    baseUrl: "http://localhost:3005",
+  }),
+  endpoints: (builder) => {
+    return {
+      fetchAlbums: builder.query({
+        query: (user) => {
+          return {
+            url: "/albums",
+            params: {
+              userId: user.id,
+            },
+            method: "GET",
+          };
+        },
+      }),
+    };
+  },
+});
+
+export const { useFetchAlbumsQuery } = albumsApi;
+export { albumsApi };

--- a/media-app/src/store/index.ts
+++ b/media-app/src/store/index.ts
@@ -1,11 +1,20 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { usersReducer } from "./slices/usersSlice";
 
+import { setupListeners } from "@reduxjs/toolkit/query";
+import { albumsApi } from "./apis/albumsApi";
+// import { useFetchAlbumsQuery } from "./apis/albumsApi";
+
 export const store = configureStore({
   reducer: {
     users: usersReducer,
+    [albumsApi.reducerPath]: albumsApi.reducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(albumsApi.middleware), // RTK Query middleware added
 });
+
+setupListeners(store.dispatch);
 
 export * from "./thunks/fetchUsers";
 export * from "./thunks/addUser";
@@ -14,3 +23,5 @@ export * from "./thunks/deleteUser";
 // These are your inferred types based on the store structure
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
+
+export { useFetchAlbumsQuery } from "./apis/albumsApi";


### PR DESCRIPTION
- Added `albumsApi` using `createApi` with `fetchBaseQuery` targeting http://localhost:3005
- Defined `fetchAlbums` query to retrieve albums by user ID
- Exported `useFetchAlbumsQuery` hook for React components

- Updated Redux store:
  - Registered `albumsApi.reducer` using computed key
  - Enabled `setupListeners(store.dispatch)` to support:
    - Refetch on window focus
    - Refetch on network reconnect
  - Exported thunk actions and inferred types (RootState, AppDispatch)

- Created `AlbumsList` component:
  - Uses `useFetchAlbumsQuery(user)` to fetch albums
  - Logs `data`, `error`, and `isLoading` for inspection
  - Renders user's name as placeholder

This sets up scalable, declarative data fetching using RTK Query.