### PR TITLE
feat(api): add tag-based cache management to albumsApi using provides Tags and invalidatesTags

### DIFF
--- a/media-app/db.json
+++ b/media-app/db.json
@@ -37,6 +37,11 @@
       "id": "8771",
       "userId": "1",
       "title": "Intelligent Aluminum Shoes"
+    },
+    {
+      "id": "b8bb",
+      "userId": "1",
+      "title": "Gorgeous Bamboo Sausages"
     }
   ],
   "photos": []

--- a/media-app/src/store/apis/albumsApi.ts
+++ b/media-app/src/store/apis/albumsApi.ts
@@ -7,6 +7,7 @@ const albumsApi = createApi({
   baseQuery: fetchBaseQuery({
     baseUrl: "http://localhost:3005",
   }),
+  tagTypes: ["Album"], // You must add this line
   endpoints: (builder) => {
     return {
       addAlbum: builder.mutation<Album, User>({
@@ -20,6 +21,9 @@ const albumsApi = createApi({
             },
           };
         },
+        invalidatesTags: (result, error, user) => [
+          { type: "Album", id: user.id },
+        ],
       }),
       fetchAlbums: builder.query<Album[], User>({
         query: (user) => {
@@ -31,6 +35,9 @@ const albumsApi = createApi({
             method: "GET",
           };
         },
+        providesTags: (result, error, user) => [
+          { type: "Album", id: user.id }, // Correct structure
+        ],
       }),
     };
   },


### PR DESCRIPTION
- Declared `tagTypes: ['Album']` to enable cache invalidation and tagging.
- Configured `fetchAlbums` to provide tags based on user ID.
- Configured `addAlbum` to invalidate corresponding Album tags on mutation.
- Ensures efficient cache updates after album creation.