### PR TITLE
refactor: extract pause utility to separate file and integrate with fetchUsers and albumsApi

### DIFF
--- a/media-app/db.json
+++ b/media-app/db.json
@@ -52,6 +52,11 @@
       "id": "7660",
       "userId": "1",
       "title": "Soft Aluminum Bacon"
+    },
+    {
+      "id": "d9f4",
+      "userId": "1",
+      "title": "Modern Aluminum Chair"
     }
   ],
   "photos": []

--- a/media-app/src/store/apis/albumsApi.ts
+++ b/media-app/src/store/apis/albumsApi.ts
@@ -1,11 +1,16 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 import { faker } from "@faker-js/faker";
 import type { Album, User } from "../../types/media";
+import { pause } from "../../utils/pause";
 
 const albumsApi = createApi({
   reducerPath: "albums",
   baseQuery: fetchBaseQuery({
     baseUrl: "http://localhost:3005",
+    fetchFn: async (...args) => {
+      await pause(1000);
+      return fetch(...args);
+    },
   }),
   tagTypes: ["Album"], // You must add this line
   endpoints: (builder) => {

--- a/media-app/src/store/thunks/fetchUsers.ts
+++ b/media-app/src/store/thunks/fetchUsers.ts
@@ -1,23 +1,12 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import axios from "axios";
 import type { User } from "../../types/media";
+import { pause } from "../../utils/pause";
 
 const fetchUsers = createAsyncThunk<User[]>("users/fetch", async () => {
   await pause(2000); // ssimulate network delay or loading pause
   const response = await axios.get<User[]>("http://localhost:3005/users");
   return response.data;
 });
-
-//DEV only
-
-const pause = (duration: number) => {
-  //console.log("Vite Mode:", import.meta.env.MODE);
-  if (import.meta.env.MODE !== "development") {
-    return Promise.resolve();
-  }
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, duration);
-  });
-};
 
 export { fetchUsers };

--- a/media-app/src/utils/pause.ts
+++ b/media-app/src/utils/pause.ts
@@ -1,0 +1,8 @@
+export const pause = (duration: number) => {
+  if (import.meta.env.MODE !== "development") {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, duration);
+  });
+};


### PR DESCRIPTION
- Moved `pause` function to a shared utility file for reuse
- Updated fetchUsers thunk to import and use the new pause utility
- Customized `fetchBaseQuery` in albumsApi to use pause via fetchFn
- Added 1s artificial delay for development mode to simulate slow network and test spinners