### PR TITLE
feat(albums): implement album deletion with cache invalidation

### DIFF
--- a/media-app/db.json
+++ b/media-app/db.json
@@ -19,16 +19,6 @@
   ],
   "albums": [
     {
-      "id": "10",
-      "title": "Hiking Trip",
-      "userId": 1
-    },
-    {
-      "id": "3eb4",
-      "userId": "1",
-      "title": "Modern Ceramic Pants"
-    },
-    {
       "id": "b4e6",
       "userId": "1",
       "title": "Awesome Concrete Salad"

--- a/media-app/src/components/AlbumsList.tsx
+++ b/media-app/src/components/AlbumsList.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import type { User } from "../types/media";
 import { useAddAlbumMutation, useFetchAlbumsQuery } from "../store";
 import Skeleton from "./Skeleton";
-import ExpandablePanel from "./ExpandablePanel";
 import Button from "./Button";
+import AlbumsListItem from "./AlbumsListItem";
 
 interface AlbumsListProps {
   user: User;
@@ -21,12 +21,7 @@ const AlbumsList: React.FC<AlbumsListProps> = ({ user }) => {
     content = <div> Error Loading Albums</div>;
   } else if (data) {
     content = data.map((album) => {
-      const header = <div>{album.title}</div>;
-      return (
-        <ExpandablePanel key={album.id} header={header}>
-          List of Photos in the albums
-        </ExpandablePanel>
-      );
+      return <AlbumsListItem key={album.id} album={album} />;
     });
   }
 

--- a/media-app/src/components/AlbumsListItem.tsx
+++ b/media-app/src/components/AlbumsListItem.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import ExpandablePanel from "./ExpandablePanel";
+import type { Album } from "../types/media";
+import { GoTrash } from "react-icons/go";
+import { useDeleteAlbumMutation } from "../store";
+import Button from "./Button";
+
+interface AlbumsListItemProps {
+  album: Album;
+}
+
+const AlbumsListItem: React.FC<AlbumsListItemProps> = ({ album }) => {
+  const [deleteAlbum, results] = useDeleteAlbumMutation();
+
+  const handleRemoveAlbum = () => {
+    deleteAlbum(album);
+  };
+  const header = (
+    <>
+      <Button
+        className="mr-2"
+        onClick={handleRemoveAlbum}
+        loading={results.isLoading}
+      >
+        <GoTrash />
+      </Button>
+
+      {album.title}
+    </>
+  );
+
+  return (
+    <ExpandablePanel key={album.id} header={header}>
+      List of Photos in the albums
+    </ExpandablePanel>
+  );
+};
+
+export default AlbumsListItem;

--- a/media-app/src/output.css
+++ b/media-app/src/output.css
@@ -199,6 +199,9 @@
   .mx-auto {
     margin-inline: auto;
   }
+  .mr-2 {
+    margin-right: calc(var(--spacing) * 2);
+  }
   .mr-3 {
     margin-right: calc(var(--spacing) * 3);
   }

--- a/media-app/src/store/apis/albumsApi.ts
+++ b/media-app/src/store/apis/albumsApi.ts
@@ -30,6 +30,17 @@ const albumsApi = createApi({
           { type: "Album", id: user.id },
         ],
       }),
+      deleteAlbum: builder.mutation<Album, Album>({
+        query: (album) => {
+          return {
+            url: `/albums/${album.id}`,
+            method: "DELETE",
+          };
+        },
+        invalidatesTags: (result, error, album) => [
+          { type: "Album", id: album.userId },
+        ],
+      }),
       fetchAlbums: builder.query<Album[], User>({
         query: (user) => {
           return {
@@ -48,5 +59,9 @@ const albumsApi = createApi({
   },
 });
 
-export const { useFetchAlbumsQuery, useAddAlbumMutation } = albumsApi;
+export const {
+  useFetchAlbumsQuery,
+  useAddAlbumMutation,
+  useDeleteAlbumMutation,
+} = albumsApi;
 export { albumsApi };

--- a/media-app/src/store/index.ts
+++ b/media-app/src/store/index.ts
@@ -23,4 +23,8 @@ export * from "./thunks/deleteUser";
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
 
-export { useFetchAlbumsQuery, useAddAlbumMutation } from "./apis/albumsApi";
+export {
+  useFetchAlbumsQuery,
+  useAddAlbumMutation,
+  useDeleteAlbumMutation,
+} from "./apis/albumsApi";


### PR DESCRIPTION
- Added useDeleteAlbumMutation hook and used it in AlbumsListItem component.

- Implemented delete button with loading state using GoTrash icon and custom Button.

- Updated albumsApi.ts to define deleteAlbum mutation.

- Used invalidatesTags with { type: 'Album', id: album.userId } to trigger refetch for correct user.

- Rendered AlbumsListItem dynamically inside AlbumsList.tsx based on API response.