### PR TITLE
refactor: add support for tagTypes in albumsApi for precise cache invalidation

### DIFF
--- a/media-app/db.json
+++ b/media-app/db.json
@@ -19,16 +19,6 @@
   ],
   "albums": [
     {
-      "id": "b4e6",
-      "userId": "1",
-      "title": "Awesome Concrete Salad"
-    },
-    {
-      "id": "8771",
-      "userId": "1",
-      "title": "Intelligent Aluminum Shoes"
-    },
-    {
       "id": "b8bb",
       "userId": "1",
       "title": "Gorgeous Bamboo Sausages"

--- a/media-app/src/components/AlbumsList.tsx
+++ b/media-app/src/components/AlbumsList.tsx
@@ -9,13 +9,13 @@ interface AlbumsListProps {
   user: User;
 }
 const AlbumsList: React.FC<AlbumsListProps> = ({ user }) => {
-  const { data, error, isLoading } = useFetchAlbumsQuery(user);
+  const { data, error, isFetching } = useFetchAlbumsQuery(user);
 
   const [addAlbum, results] = useAddAlbumMutation();
   console.log(results);
 
   let content;
-  if (isLoading) {
+  if (isFetching) {
     content = <Skeleton times={4} className="h-10 w-full" />;
   } else if (error) {
     content = <div> Error Loading Albums</div>;

--- a/media-app/src/output.css
+++ b/media-app/src/output.css
@@ -214,9 +214,6 @@
   .flex {
     display: flex;
   }
-  .table {
-    display: table;
-  }
   .h-6 {
     height: calc(var(--spacing) * 6);
   }
@@ -232,12 +229,6 @@
   .w-full {
     width: 100%;
   }
-  .border-collapse {
-    border-collapse: collapse;
-  }
-  .transform {
-    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
-  }
   .animate-pulse {
     animation: var(--animate-pulse);
   }
@@ -246,9 +237,6 @@
   }
   .cursor-pointer {
     cursor: pointer;
-  }
-  .resize {
-    resize: both;
   }
   .flex-row {
     flex-direction: row;
@@ -318,9 +306,6 @@
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
   }
-  .py-1 {
-    padding-block: calc(var(--spacing) * 1);
-  }
   .py-1\.5 {
     padding-block: calc(var(--spacing) * 1.5);
   }
@@ -354,9 +339,6 @@
   .text-yellow-400 {
     color: var(--color-yellow-400);
   }
-  .underline {
-    text-decoration-line: underline;
-  }
   .opacity-80 {
     opacity: 80%;
   }
@@ -368,26 +350,6 @@
     outline-style: var(--tw-outline-style);
     outline-width: 1px;
   }
-}
-@property --tw-rotate-x {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-rotate-y {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-rotate-z {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-skew-x {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-skew-y {
-  syntax: "*";
-  inherits: false;
 }
 @property --tw-border-style {
   syntax: "*";
@@ -481,11 +443,6 @@
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
-      --tw-rotate-x: initial;
-      --tw-rotate-y: initial;
-      --tw-rotate-z: initial;
-      --tw-skew-x: initial;
-      --tw-skew-y: initial;
       --tw-border-style: solid;
       --tw-font-weight: initial;
       --tw-shadow: 0 0 #0000;


### PR DESCRIPTION
- Introduced tagTypes: ["Album", "UsersAlbums"] to enable more granular cache management.

- Updated providesTags in fetchAlbums to return tags for individual albums and the user's album list.

- Updated invalidatesTags in addAlbum and deleteAlbum to invalidate correct tag types (UsersAlbums and Album respectively).

- Added a pause function in the custom fetchFn to simulate delayed API responses for debugging and testing UI states.