### PR TITLE
feat(photos): implement photo listing with add and delete functionality per album

### DIFF
--- a/media-app/db.json
+++ b/media-app/db.json
@@ -39,5 +39,16 @@
       "title": "Modern Aluminum Chair"
     }
   ],
-  "photos": []
+  "photos": [
+    {
+      "id": "e145",
+      "albumId": "b8bb",
+      "url": "https://picsum.photos/seed/lVmEvbem/150/150"
+    },
+    {
+      "id": "3e43",
+      "albumId": "b8bb",
+      "url": "https://picsum.photos/seed/KOM7u/150/150"
+    }
+  ]
 }

--- a/media-app/src/components/AlbumsListItem.tsx
+++ b/media-app/src/components/AlbumsListItem.tsx
@@ -4,6 +4,7 @@ import type { Album } from "../types/media";
 import { GoTrash } from "react-icons/go";
 import { useDeleteAlbumMutation } from "../store";
 import Button from "./Button";
+import PhotosList from "./PhotosList";
 
 interface AlbumsListItemProps {
   album: Album;
@@ -31,7 +32,7 @@ const AlbumsListItem: React.FC<AlbumsListItemProps> = ({ album }) => {
 
   return (
     <ExpandablePanel key={album.id} header={header}>
-      List of Photos in the albums
+      <PhotosList album={album} />
     </ExpandablePanel>
   );
 };

--- a/media-app/src/components/PhotosList.tsx
+++ b/media-app/src/components/PhotosList.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import type { Album } from "../types/media";
+import { useAddPhotoMutation, useFetchPhotosQuery } from "../store";
+import Skeleton from "./Skeleton";
+import PhotosListItem from "./PhotosListItem";
+import Button from "./Button";
+
+interface PhotosListProps {
+  album: Album;
+}
+
+const PhotosList: React.FC<PhotosListProps> = ({ album }) => {
+  const { data, error, isFetching } = useFetchPhotosQuery(album);
+
+  const [addPhoto, results] = useAddPhotoMutation();
+  console.log(results);
+
+  let content;
+  if (isFetching) {
+    content = <Skeleton times={4} className="h-10 w-full" />;
+  } else if (error) {
+    content = <div> Error Fetching Photos</div>;
+  } else if (data) {
+    content = data.map((photo) => {
+      return <PhotosListItem key={photo.id} photo={photo} />;
+    });
+  }
+
+  const handleAddPhoto = () => {
+    addPhoto(album);
+  };
+
+  return (
+    <div>
+      <div className="m-2 flex flex-row items-center justify-between">
+        <h3 className="text-lg font-bold">Photos for {album.title}</h3>
+
+        <Button onClick={handleAddPhoto} loading={results.isLoading}>
+          + Add Photo
+        </Button>
+      </div>
+      <div className="mx-8 flex flex-row flex-wrap justify-center">
+        {content}
+      </div>
+    </div>
+  );
+};
+
+export default PhotosList;

--- a/media-app/src/components/PhotosListItem.tsx
+++ b/media-app/src/components/PhotosListItem.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { useDeletePhotoMutation } from "../store";
+import { GoTrash } from "react-icons/go";
+import type { Photo } from "../types/media";
+import ExpandablePanel from "./ExpandablePanel";
+
+interface PhotosListItemProps {
+  photo: Photo;
+}
+
+const PhotosListItem: React.FC<PhotosListItemProps> = ({ photo }) => {
+  const [deletePhoto] = useDeletePhotoMutation();
+
+  const handleRemovePhoto = () => {
+    deletePhoto(photo);
+  };
+  const header = (
+    <div className="relative m-2 cursor-pointer" onClick={handleRemovePhoto}>
+      <img className="h-20 w-20" src={photo.url} alt="Random pics" />
+      <div className="absolute inset-0 flex items-center justify-center hover:bg-gray-200 opacity-0 hover:opacity-80">
+        <GoTrash className="text-3xl" />
+      </div>
+    </div>
+  );
+
+  return (
+    <ExpandablePanel
+      key={photo.id}
+      header={header}
+      children={undefined}
+    ></ExpandablePanel>
+  );
+};
+
+export default PhotosListItem;

--- a/media-app/src/output.css
+++ b/media-app/src/output.css
@@ -19,6 +19,8 @@
     --text-lg--line-height: calc(1.75 / 1.125);
     --text-xl: 1.25rem;
     --text-xl--line-height: calc(1.75 / 1.25);
+    --text-3xl: 1.875rem;
+    --text-3xl--line-height: calc(2.25 / 1.875);
     --font-weight-bold: 700;
     --animate-spin: spin 1s linear infinite;
     --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
@@ -172,6 +174,15 @@
   }
 }
 @layer utilities {
+  .absolute {
+    position: absolute;
+  }
+  .relative {
+    position: relative;
+  }
+  .inset-0 {
+    inset: calc(var(--spacing) * 0);
+  }
   .container {
     width: 100%;
     @media (width >= 40rem) {
@@ -196,6 +207,9 @@
   .m-3 {
     margin: calc(var(--spacing) * 3);
   }
+  .mx-8 {
+    margin-inline: calc(var(--spacing) * 8);
+  }
   .mx-auto {
     margin-inline: auto;
   }
@@ -214,6 +228,9 @@
   .flex {
     display: flex;
   }
+  .table {
+    display: table;
+  }
   .h-6 {
     height: calc(var(--spacing) * 6);
   }
@@ -223,11 +240,23 @@
   .h-10 {
     height: calc(var(--spacing) * 10);
   }
+  .h-20 {
+    height: calc(var(--spacing) * 20);
+  }
+  .w-20 {
+    width: calc(var(--spacing) * 20);
+  }
   .w-48 {
     width: calc(var(--spacing) * 48);
   }
   .w-full {
     width: 100%;
+  }
+  .border-collapse {
+    border-collapse: collapse;
+  }
+  .transform {
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .animate-pulse {
     animation: var(--animate-pulse);
@@ -238,14 +267,23 @@
   .cursor-pointer {
     cursor: pointer;
   }
+  .resize {
+    resize: both;
+  }
   .flex-row {
     flex-direction: row;
+  }
+  .flex-wrap {
+    flex-wrap: wrap;
   }
   .items-center {
     align-items: center;
   }
   .justify-between {
     justify-content: space-between;
+  }
+  .justify-center {
+    justify-content: center;
   }
   .rounded {
     border-radius: 0.25rem;
@@ -306,8 +344,15 @@
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
   }
+  .py-1 {
+    padding-block: calc(var(--spacing) * 1);
+  }
   .py-1\.5 {
     padding-block: calc(var(--spacing) * 1.5);
+  }
+  .text-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
   }
   .text-lg {
     font-size: var(--text-lg);
@@ -339,6 +384,12 @@
   .text-yellow-400 {
     color: var(--color-yellow-400);
   }
+  .underline {
+    text-decoration-line: underline;
+  }
+  .opacity-0 {
+    opacity: 0%;
+  }
   .opacity-80 {
     opacity: 80%;
   }
@@ -350,6 +401,40 @@
     outline-style: var(--tw-outline-style);
     outline-width: 1px;
   }
+  .hover\:bg-gray-200 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-200);
+      }
+    }
+  }
+  .hover\:opacity-80 {
+    &:hover {
+      @media (hover: hover) {
+        opacity: 80%;
+      }
+    }
+  }
+}
+@property --tw-rotate-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-z {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-y {
+  syntax: "*";
+  inherits: false;
 }
 @property --tw-border-style {
   syntax: "*";
@@ -443,6 +528,11 @@
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
+      --tw-rotate-x: initial;
+      --tw-rotate-y: initial;
+      --tw-rotate-z: initial;
+      --tw-skew-x: initial;
+      --tw-skew-y: initial;
       --tw-border-style: solid;
       --tw-font-weight: initial;
       --tw-shadow: 0 0 #0000;

--- a/media-app/src/store/apis/photosApi.ts
+++ b/media-app/src/store/apis/photosApi.ts
@@ -1,0 +1,80 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { pause } from "../../utils/pause";
+import type { Album, Photo } from "../../types/media";
+import { faker } from "@faker-js/faker";
+
+const photosApi = createApi({
+  reducerPath: "photos",
+  baseQuery: fetchBaseQuery({
+    baseUrl: "http://localhost:3005",
+    fetchFn: async (...args) => {
+      await pause(1000);
+      return fetch(...args);
+    },
+  }),
+  tagTypes: ["Photo", "AlbumPhotos"] as const, // You must add this line
+  endpoints: (builder) => {
+    return {
+      addPhoto: builder.mutation<Photo, Album>({
+        query: (album) => {
+          return {
+            url: "/photos",
+            method: "POST",
+            body: {
+              albumId: album.id,
+              url: faker.image.url({ width: 150, height: 150 }),
+            },
+          };
+        },
+        invalidatesTags: (result, error, album) => [
+          { type: "AlbumPhotos" as const, id: album.id },
+        ],
+      }),
+      deletePhoto: builder.mutation<Photo, Photo>({
+        query: (photo) => {
+          return {
+            url: `/photos/${photo.id}`,
+            method: "DELETE",
+          };
+        },
+        invalidatesTags: (result, error, photo) => [
+          { type: "Photo" as const, id: photo.id },
+        ],
+      }),
+      fetchPhotos: builder.query<Photo[], Album>({
+        query: (album) => {
+          return {
+            url: "/photos",
+            params: {
+              albumId: album.id,
+            },
+            method: "GET",
+          };
+        },
+        providesTags: (result, error, album) => {
+          const tags: (
+            | { type: "Photo"; id: number }
+            | { type: "AlbumPhotos"; id: number }
+          )[] = [];
+
+          if (result) {
+            for (const photo of result) {
+              tags.push({ type: "Photo", id: photo.id });
+            }
+          }
+
+          tags.push({ type: "AlbumPhotos", id: album.id });
+          return tags;
+        },
+      }),
+    };
+  },
+});
+
+export const {
+  useFetchPhotosQuery,
+  useAddPhotoMutation,
+  useDeletePhotoMutation,
+} = photosApi;
+
+export { photosApi };

--- a/media-app/src/store/index.ts
+++ b/media-app/src/store/index.ts
@@ -3,14 +3,16 @@ import { usersReducer } from "./slices/usersSlice";
 
 import { setupListeners } from "@reduxjs/toolkit/query";
 import { albumsApi } from "./apis/albumsApi";
+import { photosApi } from "./apis/photosApi";
 
 export const store = configureStore({
   reducer: {
     users: usersReducer,
     [albumsApi.reducerPath]: albumsApi.reducer,
+    [photosApi.reducerPath]: photosApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(albumsApi.middleware), // RTK Query middleware added
+    getDefaultMiddleware().concat(albumsApi.middleware, photosApi.middleware), // RTK Query middleware added
 });
 
 setupListeners(store.dispatch);
@@ -28,3 +30,9 @@ export {
   useAddAlbumMutation,
   useDeleteAlbumMutation,
 } from "./apis/albumsApi";
+
+export {
+  useFetchPhotosQuery,
+  useAddPhotoMutation,
+  useDeletePhotoMutation,
+} from "./apis/photosApi";


### PR DESCRIPTION
- Created `PhotosList.tsx` to fetch and render photos for a specific album using `useFetchPhotosQuery`
- Built `PhotosListItem.tsx` to show individual photos with hover overlay and a delete icon
  - Added delete functionality using `useRemovePhotoMutation`
  - Styled hover overlay with Tailwind: `absolute inset-0 flex items-center justify-center hover:bg-gray-200 opacity-0 hover:opacity-80 text-3xl`
- Updated `AlbumsListItem.tsx` to embed `PhotosList` inside the expandable panel for each album
- Created `photosApi.ts` in RTK Query with endpoints:
  - `fetchPhotos` with album ID
  - `addPhoto` mutation that uses `faker.image.url()` with cache-busting query string
  - `removePhoto` mutation to delete photos
  - Implemented proper tagging to support automatic cache refetch after add/remove
- Registered `photosApi.reducer` and `photosApi.middleware` in Redux store config (`store/index.ts`)